### PR TITLE
Fix manager registry key collision and incorrect session closing

### DIFF
--- a/src/ca_bhfuil/core/managers/base.py
+++ b/src/ca_bhfuil/core/managers/base.py
@@ -192,35 +192,35 @@ class ManagerRegistry:
 
     def __init__(self) -> None:
         """Initialize empty manager registry."""
-        self._managers: dict[type, typing.Any] = {}
+        self._managers: dict[str, typing.Any] = {}
         self._db_session: sqlalchemy.ext.asyncio.AsyncSession | None = None
         self._db_manager: sqlmodel_manager.SQLModelDatabaseManager | None = None
 
-    def register(self, manager_type: type, manager_instance: typing.Any) -> None:
+    def register(self, manager_key: str, manager_instance: typing.Any) -> None:
         """Register a manager instance.
 
         Args:
-            manager_type: The type/class of the manager
+            manager_key: String key for instance-specific tracking
             manager_instance: The manager instance to register
         """
-        self._managers[manager_type] = manager_instance
-        logger.debug(f"Registered manager: {manager_type.__name__}")
+        self._managers[manager_key] = manager_instance
+        logger.debug(f"Registered manager: {manager_key}")
 
-    def get(self, manager_type: type[T]) -> T:
+    def get(self, manager_key: str) -> typing.Any:
         """Get a registered manager instance.
 
         Args:
-            manager_type: The type of manager to retrieve
+            manager_key: String key of manager to retrieve
 
         Returns:
             The registered manager instance
 
         Raises:
-            KeyError: If manager type is not registered
+            KeyError: If manager key is not registered
         """
-        if manager_type not in self._managers:
-            raise KeyError(f"Manager type {manager_type.__name__} not registered")
-        return typing.cast("T", self._managers[manager_type])
+        if manager_key not in self._managers:
+            raise KeyError(f"Manager key '{manager_key}' not registered")
+        return self._managers[manager_key]
 
     async def set_shared_database_manager(
         self, db_manager: sqlmodel_manager.SQLModelDatabaseManager

--- a/src/ca_bhfuil/core/managers/base.py
+++ b/src/ca_bhfuil/core/managers/base.py
@@ -14,6 +14,7 @@ from ca_bhfuil.storage.database import repository as db_repository
 
 # Type variable for generic result types
 T = typing.TypeVar("T", bound=result_models.OperationResult)
+ManagerKey = str
 
 
 class BaseManager:
@@ -192,11 +193,11 @@ class ManagerRegistry:
 
     def __init__(self) -> None:
         """Initialize empty manager registry."""
-        self._managers: dict[str, typing.Any] = {}
+        self._managers: dict[ManagerKey, typing.Any] = {}
         self._db_session: sqlalchemy.ext.asyncio.AsyncSession | None = None
         self._db_manager: sqlmodel_manager.SQLModelDatabaseManager | None = None
 
-    def register(self, manager_key: str, manager_instance: typing.Any) -> None:
+    def register(self, manager_key: ManagerKey, manager_instance: typing.Any) -> None:
         """Register a manager instance.
 
         Args:
@@ -206,17 +207,25 @@ class ManagerRegistry:
         self._managers[manager_key] = manager_instance
         logger.debug(f"Registered manager: {manager_key}")
 
-    def get(self, manager_key: str) -> typing.Any:
+    def get(self, manager_key: ManagerKey) -> typing.Any:
         """Get a registered manager instance.
 
         Args:
             manager_key: String key of manager to retrieve
 
         Returns:
-            The registered manager instance
+            The registered manager instance (use type hints for specific type)
 
         Raises:
             KeyError: If manager key is not registered
+
+        Note:
+            Return type is `typing.Any` to accommodate different manager types.
+            Consider using type hints when calling this method to restore type safety:
+
+            ```python
+            manager: RepositoryManager = registry.get("repository:/path/to/repo")
+            ```
         """
         if manager_key not in self._managers:
             raise KeyError(f"Manager key '{manager_key}' not registered")

--- a/src/ca_bhfuil/core/managers/factory.py
+++ b/src/ca_bhfuil/core/managers/factory.py
@@ -69,7 +69,7 @@ class ManagerFactory:
 
         # Register with registry for tracking
         manager_key = f"repository:{repository_path}"
-        self._registry.register(type(manager_key), repo_manager)
+        self._registry.register(manager_key, repo_manager)
 
         return repo_manager
 

--- a/src/ca_bhfuil/core/managers/repository.py
+++ b/src/ca_bhfuil/core/managers/repository.py
@@ -417,4 +417,3 @@ class RepositoryManager(base_manager.BaseManager):
 
         except Exception as e:
             logger.error(f"Failed to cache commits to database: {e}")
-

--- a/src/ca_bhfuil/core/managers/repository.py
+++ b/src/ca_bhfuil/core/managers/repository.py
@@ -418,7 +418,3 @@ class RepositoryManager(base_manager.BaseManager):
         except Exception as e:
             logger.error(f"Failed to cache commits to database: {e}")
 
-    async def close(self) -> None:
-        """Close database connections and clean up resources."""
-        if self._db_session:
-            await self._db_session.close()

--- a/tests/unit/test_base_manager.py
+++ b/tests/unit/test_base_manager.py
@@ -221,16 +221,16 @@ class TestManagerRegistry:
         mock_manager = unittest.mock.MagicMock()
 
         # Register manager
-        registry.register(str, mock_manager)
+        registry.register("test_manager", mock_manager)
 
         # Retrieve manager
-        retrieved = registry.get(str)
+        retrieved = registry.get("test_manager")
         assert retrieved is mock_manager
 
     async def test_get_unregistered_manager(self, registry):
         """Test retrieving unregistered manager raises error."""
-        with pytest.raises(KeyError, match="Manager type int not registered"):
-            registry.get(int)
+        with pytest.raises(KeyError, match="Manager key 'nonexistent' not registered"):
+            registry.get("nonexistent")
 
     @pytest.fixture
     async def db_session(self, tmp_path):

--- a/tests/unit/test_manager_resource_management.py
+++ b/tests/unit/test_manager_resource_management.py
@@ -1,0 +1,117 @@
+"""Tests for manager resource management fixes."""
+
+import pathlib
+import tempfile
+import unittest.mock
+
+import pytest
+
+from ca_bhfuil.core.managers import factory as manager_factory
+from tests.fixtures import alembic
+
+
+class TestManagerResourceManagement:
+    """Test the fixed resource management issues."""
+
+    async def test_manager_registry_key_collision_fix(self, tmp_path):
+        """Test that manager registry now properly tracks separate instances."""
+        db_path = tmp_path / "test.db"
+        await alembic.create_test_database(db_path)
+
+        async with manager_factory.ManagerFactory(db_path) as factory:
+            with tempfile.TemporaryDirectory() as temp_dir1, \
+                 tempfile.TemporaryDirectory() as temp_dir2:
+
+                repo_path1 = pathlib.Path(temp_dir1)
+                repo_path2 = pathlib.Path(temp_dir2)
+
+                # Mock git repository to avoid needing actual git repos
+                with unittest.mock.patch(
+                    "ca_bhfuil.core.git.repository.Repository"
+                ) as mock_repo_class:
+                    mock_repo = unittest.mock.MagicMock()
+                    mock_repo.head_is_unborn = False
+                    mock_repo.get_repository_stats.return_value = {"total_branches": 1}
+                    mock_repo_class.return_value = mock_repo
+
+                    # Create two different repository managers
+                    repo_manager1 = await factory.get_repository_manager(repo_path1)
+                    repo_manager2 = await factory.get_repository_manager(repo_path2)
+
+                    # Verify they are different instances
+                    assert repo_manager1 is not repo_manager2
+
+                    # Verify they have different repository paths
+                    assert repo_manager1.repository_path != repo_manager2.repository_path
+
+                    # Verify both are registered in the registry
+                    registry = await factory.get_registry()
+                    manager1_key = f"repository:{repo_path1}"
+                    manager2_key = f"repository:{repo_path2}"
+
+                    retrieved_manager1 = registry.get(manager1_key)
+                    retrieved_manager2 = registry.get(manager2_key)
+
+                    assert retrieved_manager1 is repo_manager1
+                    assert retrieved_manager2 is repo_manager2
+
+    async def test_repository_manager_no_incorrect_session_closing(self, tmp_path):
+        """Test that RepositoryManager no longer overrides close() method."""
+        db_path = tmp_path / "test.db"
+        await alembic.create_test_database(db_path)
+
+        async with manager_factory.ManagerFactory(db_path) as factory:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                repo_path = pathlib.Path(temp_dir)
+
+                # Mock git repository
+                with unittest.mock.patch(
+                    "ca_bhfuil.core.git.repository.Repository"
+                ) as mock_repo_class:
+                    mock_repo = unittest.mock.MagicMock()
+                    mock_repo.head_is_unborn = False
+                    mock_repo.get_repository_stats.return_value = {"total_branches": 1}
+                    mock_repo_class.return_value = mock_repo
+
+                    repo_manager = await factory.get_repository_manager(repo_path)
+
+                    # Verify the manager doesn't override close method
+                    # (close method should come from BaseManager)
+                    from ca_bhfuil.core.managers import base as base_manager
+                    assert repo_manager.__class__.close is base_manager.BaseManager.close
+
+                    # Verify the manager still has close method from BaseManager
+                    assert hasattr(repo_manager, 'close')
+
+                    # Verify calling close doesn't cause issues
+                    await repo_manager.close()
+
+    async def test_manager_registry_string_keys(self, tmp_path):
+        """Test that manager registry properly handles string keys."""
+        db_path = tmp_path / "test.db"
+        await alembic.create_test_database(db_path)
+
+        factory = manager_factory.ManagerFactory(db_path)
+        await factory.initialize()
+
+        try:
+            registry = await factory.get_registry()
+
+            # Test with a mock manager that has an async close method
+            mock_manager = unittest.mock.MagicMock()
+            mock_manager.close = unittest.mock.AsyncMock()
+            test_key = "test_manager_instance"
+
+            # Register with string key
+            registry.register(test_key, mock_manager)
+
+            # Retrieve with string key
+            retrieved_manager = registry.get(test_key)
+
+            assert retrieved_manager is mock_manager
+
+            # Test error case
+            with pytest.raises(KeyError, match="Manager key 'nonexistent' not registered"):
+                registry.get("nonexistent")
+        finally:
+            await factory.close()

--- a/tests/unit/test_manager_resource_management.py
+++ b/tests/unit/test_manager_resource_management.py
@@ -19,9 +19,10 @@ class TestManagerResourceManagement:
         await alembic.create_test_database(db_path)
 
         async with manager_factory.ManagerFactory(db_path) as factory:
-            with tempfile.TemporaryDirectory() as temp_dir1, \
-                 tempfile.TemporaryDirectory() as temp_dir2:
-
+            with (
+                tempfile.TemporaryDirectory() as temp_dir1,
+                tempfile.TemporaryDirectory() as temp_dir2,
+            ):
                 repo_path1 = pathlib.Path(temp_dir1)
                 repo_path2 = pathlib.Path(temp_dir2)
 
@@ -42,7 +43,9 @@ class TestManagerResourceManagement:
                     assert repo_manager1 is not repo_manager2
 
                     # Verify they have different repository paths
-                    assert repo_manager1.repository_path != repo_manager2.repository_path
+                    assert (
+                        repo_manager1.repository_path != repo_manager2.repository_path
+                    )
 
                     # Verify both are registered in the registry
                     registry = await factory.get_registry()
@@ -78,10 +81,13 @@ class TestManagerResourceManagement:
                     # Verify the manager doesn't override close method
                     # (close method should come from BaseManager)
                     from ca_bhfuil.core.managers import base as base_manager
-                    assert repo_manager.__class__.close is base_manager.BaseManager.close
+
+                    assert (
+                        repo_manager.__class__.close is base_manager.BaseManager.close
+                    )
 
                     # Verify the manager still has close method from BaseManager
-                    assert hasattr(repo_manager, 'close')
+                    assert hasattr(repo_manager, "close")
 
                     # Verify calling close doesn't cause issues
                     await repo_manager.close()
@@ -111,7 +117,9 @@ class TestManagerResourceManagement:
             assert retrieved_manager is mock_manager
 
             # Test error case
-            with pytest.raises(KeyError, match="Manager key 'nonexistent' not registered"):
+            with pytest.raises(
+                KeyError, match="Manager key 'nonexistent' not registered"
+            ):
                 registry.get("nonexistent")
         finally:
             await factory.close()


### PR DESCRIPTION
## Summary

This PR addresses two high-priority issues identified in Gemini Code Assist feedback from the previous async context manager refactoring PR:

### 🐛 Issue 1: Manager Registry Key Collision
- **Problem**: `ManagerFactory.get_repository_manager()` was using `type(manager_key)` instead of the actual string key
- **Impact**: All RepositoryManager instances were overwriting each other in the registry, causing resource leaks
- **Solution**: Fixed line 72 in `factory.py` to use the actual `manager_key` string for proper instance tracking

### 🐛 Issue 2: Incorrect Session Closing  
- **Problem**: `RepositoryManager` was overriding the `close()` method and incorrectly closing shared sessions
- **Impact**: Could cause `DetachedInstanceError` when sessions were managed externally
- **Solution**: Removed the incorrect `close()` method override so it properly inherits from `BaseManager`

### ✨ Additional Improvements
- **Updated ManagerRegistry**: Modified to use string keys consistently for instance-specific tracking
- **Enhanced Registry Methods**: Updated `register()` and `get()` methods to handle string keys properly
- **Fixed Related Tests**: Updated base manager tests to use the new string-based approach
- **Added Comprehensive Tests**: Created new test file to verify the fixes work correctly

## Test Plan

- [x] All existing tests continue to pass (400+ tests passing)
- [x] New tests verify the fixes work correctly:
  - Manager registry properly tracks separate instances
  - RepositoryManager no longer overrides close() method
  - Manager registry handles string keys correctly
- [x] Code follows project style guidelines (ruff and mypy clean)
- [x] Comprehensive test coverage for resource management scenarios

## Key Changes

### Core Fixes
- `src/ca_bhfuil/core/managers/factory.py`: Fixed registry key collision
- `src/ca_bhfuil/core/managers/repository.py`: Removed incorrect close() override
- `src/ca_bhfuil/core/managers/base.py`: Updated registry to use string keys

### Test Updates
- `tests/unit/test_base_manager.py`: Fixed tests to use string keys
- `tests/unit/test_manager_resource_management.py`: Added comprehensive tests

## Impact

The fixes ensure:
- ✅ Multiple RepositoryManager instances are properly tracked separately
- ✅ Shared database sessions are not incorrectly closed
- ✅ Manager registry provides proper cleanup and resource management
- ✅ All existing functionality remains intact

🤖 Generated with [Claude Code](https://claude.ai/code)